### PR TITLE
Fixing to inclusive upper limit of tlush end date

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage of ./getlush:
   -cookie string
         Path to cookie file (default "hilan.cookie")
   -emp string
-        Employee citizenship ID number (not userid) [required]
+        Employee citizenship ID number [required]
   -from value
         First payslip to fetch (YYYY-MM) [required]
   -org string

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage of ./getlush:
   -cookie string
         Path to cookie file (default "hilan.cookie")
   -emp string
-        Employee ID number (not userid) [required]
+        Employee citizenship ID number (not userid) [required]
   -from value
         First payslip to fetch (YYYY-MM) [required]
   -org string

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Batch downloader for payslips from Hilan.
     - Login to Hilan as you normally would and view your latest payslip.
     - Find a request that looks like `PaySlip2022-01.pdf?Date=01/01/2022&UserId=12341231231`.
     - Go to `Request Headers` on the bottom right and copy the `Cookie` header.
-    - Save the value to a file, e.g. `hilan.cookie`.
+    - Save the value to a file, e.g. `hilan.cookie` under `bin` directory.
 
-2. Run `getlush` with your details - for example:  
-    `$ ./bin/getlush -emp 123123123 -from 2015-01 -to 2022-01`
+2. Create executable file by running `make`
+
+3. Run `getlush` with your details - for example:  
+    `$ ./bin/getlush -emp 209935777 -from 2015-01 -to 2022-01`
 
 
 ### Config
@@ -23,7 +25,7 @@ Usage of ./getlush:
   -cookie string
         Path to cookie file (default "hilan.cookie")
   -emp string
-        Employee ID [required]
+        Employee ID number (not userid) [required]
   -from value
         First payslip to fetch (YYYY-MM) [required]
   -org string

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func (cfg *Config) bindFlags(fs *flag.FlagSet) {
 	)
 	fs.StringVar(&cfg.url, "url", traianaURL, "Hilan's base URL")
 	fs.StringVar(&cfg.org, "org", traianaOrgID, "Parent organization ID")
-	fs.StringVar(&cfg.emp, "emp", "", "Employee ID [required]")
+	fs.StringVar(&cfg.emp, "emp", "", "Employee ID number (not userid) [required]")
 	fs.Var(&cfg.from, "from", "First payslip to fetch (YYYY-MM) [required]")
 	fs.Var(&cfg.to, "to", "Last payslip to fetch (YYYY-MM) [required]")
 	fs.StringVar(&cfg.cookiePath, "cookie", "hilan.cookie", "Path to cookie file")

--- a/config.go
+++ b/config.go
@@ -73,3 +73,8 @@ func (h *hilanDate) Set(s string) error {
 	h.Time = t
 	return nil
 }
+
+// BeforeOrEqual t time is before or equal to h hilanDate , aka h is inclusive upper limit
+func (h *hilanDate) BeforeOrEqual(t *time.Time) bool {
+	return t.Before(h.Time) || t.Equal(h.Time)
+}

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func (cfg *Config) bindFlags(fs *flag.FlagSet) {
 	)
 	fs.StringVar(&cfg.url, "url", traianaURL, "Hilan's base URL")
 	fs.StringVar(&cfg.org, "org", traianaOrgID, "Parent organization ID")
-	fs.StringVar(&cfg.emp, "emp", "", "Employee ID number (not userid) [required]")
+	fs.StringVar(&cfg.emp, "emp", "", "Employee citizenship ID number (not userid) [required]")
 	fs.Var(&cfg.from, "from", "First payslip to fetch (YYYY-MM) [required]")
 	fs.Var(&cfg.to, "to", "Last payslip to fetch (YYYY-MM) [required]")
 	fs.StringVar(&cfg.cookiePath, "cookie", "hilan.cookie", "Path to cookie file")

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func (cfg *Config) bindFlags(fs *flag.FlagSet) {
 	)
 	fs.StringVar(&cfg.url, "url", traianaURL, "Hilan's base URL")
 	fs.StringVar(&cfg.org, "org", traianaOrgID, "Parent organization ID")
-	fs.StringVar(&cfg.emp, "emp", "", "Employee citizenship ID number (not userid) [required]")
+	fs.StringVar(&cfg.emp, "emp", "", "Employee citizenship ID number [required]")
 	fs.Var(&cfg.from, "from", "First payslip to fetch (YYYY-MM) [required]")
 	fs.Var(&cfg.to, "to", "Last payslip to fetch (YYYY-MM) [required]")
 	fs.StringVar(&cfg.cookiePath, "cookie", "hilan.cookie", "Path to cookie file")

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	// payslips for each month
 	payslipFn := requestFnPayslip(cfg, cookie)
-	for cur := cfg.from.Time; cfg.to.After(cur); cur = cur.AddDate(0, 1, 0) {
+	for cur := cfg.from.Time; cfg.to.BeforeOrEqual(&cur); cur = cur.AddDate(0, 1, 0) {
 		id := cur.Format(hilanDateFmtYYYYMM) // request/file id
 		fmt.Printf(">> %s... ", id)
 		req, err := payslipFn(cur)


### PR DESCRIPTION
Small fix. The upper limit `to` was exclusive, changed it to inclusive.
Also added some clarifications in the `help` command (since I got it wrong the first time - thought that I need to take `userid` from request, and not Citizenship ID).